### PR TITLE
MySQL Support (override _detect_charset method)

### DIFF
--- a/sqlalchemy_aurora_data_api/__init__.py
+++ b/sqlalchemy_aurora_data_api/__init__.py
@@ -14,6 +14,9 @@ class AuroraMySQLDataAPIDialect(MySQLDialect):
     def dbapi(cls):
         return aurora_data_api
 
+    def _detect_charset(self, connection):
+        return connection.connection.charset
+
 
 class _ADA_SA_JSON(SA_JSON):
     def bind_expression(self, value):


### PR DESCRIPTION
To fix the bug #2 
Created `_detect_charset` method to override one in superclass.
https://github.com/sqlalchemy/sqlalchemy/blob/db47859dca999b9d1679b513fe855e408d7d07c4/lib/sqlalchemy/dialects/mysql/base.py#L2786
which rases NotImplementedError();

**Note**
Please merge https://github.com/chanzuckerberg/aurora-data-api/pull/4 first otherwise `connection.connection.charset` makes error.