### PR TITLE
Return error code instead of MySQLErrorCodes enum entry

### DIFF
--- a/sqlalchemy_aurora_data_api/__init__.py
+++ b/sqlalchemy_aurora_data_api/__init__.py
@@ -26,7 +26,7 @@ class AuroraMySQLDataAPIDialect(MySQLDialect):
         return connection.execute("SHOW VARIABLES LIKE 'character_set_client'").fetchone()[1]
 
     def _extract_error_code(self, exception):
-        return exception.args[0]
+        return exception.args[0].value
 
 
 class _ADA_SA_JSON(sqltypes.JSON):


### PR DESCRIPTION
Hi, 

I've discovered the actual implementation of the AuroraMySQL dialect return an entry of MySQLErrorCodes Enum in `_extract_error_code()` method, but SQLAlchemy needs an actual error code number to be returned by this method.

Exemple code to reproduce : 
```python
import unittest

from sqlalchemy import create_engine


class TestHasTable(unittest.TestCase):
    def test_has_table(self):
        cluster_arn = "arn:aws:rds:eu-west-1:123456789012:cluster:my-aurora-serverless-cluster"
        secret_arn = "arn:aws:secretsmanager:eu-west-1:123456789012:secret:MY_DB_CREDENTIALS"

        engine = create_engine('mysql+auroradataapi://:@/my_database',
                               echo=True,
                               connect_args=dict(aurora_cluster_arn=cluster_arn, secret_arn=secret_arn))

        self.assertFalse(engine.has_table("not_existing_table"))
```

This will result in an uncaught Exception : 
```
sqlalchemy.exc.DatabaseError: (aurora_data_api.exceptions.DatabaseError) (<MySQLErrorCodes.ER_NO_SUCH_TABLE: 1146>, "Table 'referentialData.not_existing_table' doesn't exist")
[SQL: DESCRIBE `not_existing_table`]
(Background on this error at: http://sqlalche.me/e/4xp6)
```

But in SQLAlchemy this error should be catched but the comparison fails at this moment : 
<img width="1371" alt="Capture d’écran 2020-04-14 à 15 28 45" src="https://user-images.githubusercontent.com/2420675/79230369-c67afe00-7e64-11ea-9946-0639a2385fd6.png">

Regards,
Romain
