### PR TITLE
Addressed bugs on new db setup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=/bin/bash
 
 lint:
-	ruff .
+	ruff check .
 
 test: lint
 	python ./test/test.py -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.ruff]
 line-length=120
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "sqlalchemy_aurora_data_api/__init__.py" = ["E401", "F401"]


### PR DESCRIPTION
Found a few errors when attempting to use sqlalchemy 2.0.44 and alembic 1.17.1.

1. Added text() to raw query so it is bindable. Was throwing errors that the object passed was "not bindable".
2. has_table() relies on extraction of the error code to know whether or not it needs to create a table. Thus the existing error handler (that returned the whole message) was causing an unknown exception. Effectively, alembic would never create its version table during the first upgrade. I Rewrote the function with proper filtering to return expected error code. There's a sql_state in there if we need it in the future (commented otherwise).
3. ruff had some older syntax and config so I updated that to newest standards.